### PR TITLE
[DOCS] Fix API key configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const apiInstance = new SibApiV3Sdk.ContactsApi()
 
 // Configure API key authorization: apiKey
 
-apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, 'YOUR API KEY');
+apiInstance.setApiKey(SibApiV3Sdk.ContactsApiApiKeys.apiKey, 'YOUR API KEY');
 
 let limit = 10; // Number | Number of documents per page
 let offset = 0; // Number | Index of the first document of the page

--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ Once you have [installed](#installation) the node module in your project, you ca
 ```javascript
 const SibApiV3Sdk = require('sib-api-v3-typescript');
 
-let apiInstance = new SibApiV3Sdk.AccountApi()
+const apiInstance = new SibApiV3Sdk.AccountApi()
 
 // Configure API key authorization: api-key
 
-let apiKey = apiInstance.authentications['apiKey'];
-apiKey.apiKey = "YOUR API KEY"
+apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, 'YOUR API KEY');
 
 apiInstance.getAccount().then(function(data) {
   console.log('API called successfully. Returned data: ' + data);
@@ -45,12 +44,11 @@ apiInstance.getAccount().then(function(data) {
 ```javascript
 const SibApiV3Sdk = require('sib-api-v3-typescript');
 
-let apiInstance = new SibApiV3Sdk.ContactsApi()
+const apiInstance = new SibApiV3Sdk.ContactsApi()
 
 // Configure API key authorization: apiKey
 
-let apiKey = apiInstance.authentications['apiKey'];
-apiKey.apiKey = "YOUR API KEY"
+apiInstance.setApiKey(SibApiV3Sdk.AccountApiApiKeys.apiKey, 'YOUR API KEY');
 
 let limit = 10; // Number | Number of documents per page
 let offset = 0; // Number | Index of the first document of the page


### PR DESCRIPTION
Hey, all! 

The current usage example is incorrect, because the `AccountApi`'s `authentications` member is protected (the same is true for the `ContactsApi`), so we need to use another member to actually set the API key. 

This PR updates the usage example on the README to suit Typescript particularities. 